### PR TITLE
Added section on header files

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -66,14 +66,20 @@ enum pfx_descriptor_e {
 
 ## Header Files
 
-Every C file that defines a function should have a corresponding
-header file (with same name and .h extension). Every function in the C
-file should have a prototype in the header file. The C file itself,
-and any other C file that calls a function from the C file, should
-`#include` the matching header file.
+Every C file that defines a function to be called from another file
+should have a corresponding header file (with same name and .h
+extension). Every non-private function in the C file should have a
+prototype in the header file. The C file itself, and any other C file
+that calls a function from the C file, should `#include` the matching
+header file.
 
-This allows the compiler to ensure that every call to each function has
-arguments of the correct number and type.
+For private functions, it's a good idea (but not required) to put a
+prototype at the top of the file, just to help the compiler check
+arguments.
+
+This allows the compiler to ensure that every call to each function
+has arguments of the correct number and type. Many such calls will not
+be caught by the linker.
 
 The header file with prototype is also a good location for the
 external function documentation, i.e. anything that function callers

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -64,6 +64,22 @@ enum pfx_descriptor_e {
 };
 ```
 
+## Header Files
+
+Every C file that defines a function should have a corresponding
+header file (with same name and .h extension). Every function in the C
+file should have a prototype in the header file. The C file itself,
+and any other C file that calls a function from the C file, should
+`#include` the matching header file.
+
+This allows the compiler to ensure that every call to each function has
+arguments of the correct number and type.
+
+The header file with prototype is also a good location for the
+external function documentation, i.e. anything that function callers
+need to know. The function definition is the place for documentation
+that developers who are modifying the function should know.
+
 ## Indentation
 
 Whenever a new level of curly braces is reached the lines within those curly


### PR DESCRIPTION
I've added a recommendation that all functions should have prototypes in header files. This is very useful for catching bugs that can be really hard to track down otherwise.

Also of note: we have -w passed as an option to turn off all warnings from the compiler. I realize the warnings can be annoying, but it's good practice to turn them on and correct each one. Again, the aim is to prevent difficult bugs.